### PR TITLE
Add support for ansible.vars

### DIFF
--- a/software/cm/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsibleEntity.java
+++ b/software/cm/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsibleEntity.java
@@ -19,8 +19,22 @@
 package org.apache.brooklyn.entity.cm.ansible;
 
 import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.core.annotation.Effector;
+import org.apache.brooklyn.core.annotation.EffectorParam;
+import org.apache.brooklyn.core.effector.MethodEffector;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 
 @ImplementedBy(AnsibleEntityImpl.class)
 public interface AnsibleEntity extends SoftwareProcess, AnsibleConfig {
+
+    MethodEffector<String> ANSIBLE_COMMAND = new MethodEffector<>(AnsibleEntity.class, "ansibleCommand");
+
+    @Effector(description = "Invoke an arbitrary Ansible command, optionally specifying the module (default is 'command')")
+    String ansibleCommand(
+        @EffectorParam(name="module", description = "Name of the Ansible module to invoke", defaultValue = "command")
+        String module,
+        @EffectorParam(name="args", description = "Arguments for the ansible command")
+        String args
+    );
+
 }

--- a/software/cm/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsibleLifecycleEffectorTasks.java
+++ b/software/cm/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsibleLifecycleEffectorTasks.java
@@ -48,7 +48,7 @@ public class AnsibleLifecycleEffectorTasks extends MachineLifecycleEffectorTasks
 
     protected String serviceName;
     protected SshFeed serviceSshFeed;
-    
+
     public AnsibleLifecycleEffectorTasks() {
     }
 
@@ -111,11 +111,11 @@ public class AnsibleLifecycleEffectorTasks extends MachineLifecycleEffectorTasks
             LOG.warn("No way to check whether "+entity()+" is running; assuming yes");
         }
         entity().sensors().set(SoftwareProcess.SERVICE_UP, true);
-        
+
         Maybe<SshMachineLocation> machine = Locations.findUniqueSshMachineLocation(entity().getLocations());
 
         if (machine.isPresent()) {
-            
+
             String serviceName = String.format("[%s]%s", entity().config().get(SERVICE_NAME).substring(0, 1),
                     entity().config().get(SERVICE_NAME).substring(1));
             String checkCmd = String.format("ps -ef | grep %s", serviceName);
@@ -134,7 +134,7 @@ public class AnsibleLifecycleEffectorTasks extends MachineLifecycleEffectorTasks
                             .setOnSuccess(true)
                             .setOnFailureOrException(false))
                     .build();
-                    
+
              entity().feeds().addFeed(serviceSshFeed);
         } else {
             LOG.warn("Location(s) {} not an ssh-machine location, so not polling for status; setting serviceUp immediately", entity().getLocations());

--- a/software/cm/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsiblePlaybookTasks.java
+++ b/software/cm/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsiblePlaybookTasks.java
@@ -19,16 +19,20 @@
 package org.apache.brooklyn.entity.cm.ansible;
 
 import org.apache.brooklyn.api.entity.Entity;
-
 import org.apache.brooklyn.api.mgmt.TaskFactory;
 import org.apache.brooklyn.core.effector.EffectorTasks;
 import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.core.task.system.ProcessTaskFactory;
 import org.apache.brooklyn.util.net.Urls;
 import org.apache.brooklyn.util.ssh.BashCommands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static org.apache.brooklyn.util.ssh.BashCommands.sudo;
 
 public class AnsiblePlaybookTasks {
     private static final Logger LOG = LoggerFactory.getLogger(AnsiblePlaybookTasks.class);
@@ -68,5 +72,11 @@ public class AnsiblePlaybookTasks {
         return SshEffectorTasks.ssh(cdAndRun(ansibleDirectory, cmd)).
                 summary("run ansible playbook for " + playbookName).requiringExitCodeZero();
     }
-    
+
+    public static ProcessTaskFactory<Integer> moduleCommand(String module, String args) {
+        final String command = "ansible localhost -m '" + module + "' -a '" + args + "'";
+        return SshEffectorTasks.ssh(sudo(command))
+            .summary("ad-hoc: " + command).requiringExitCodeZero();
+    }
 }
+


### PR DESCRIPTION
This allows the blueprint author to specify Ansible variables in the blueprint, to provide values overriding the defaults in the playbook.

e.g.

``` yaml
name: test3
location: byon2
services:
  - type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
    id: apache
    name: apc
    service.name: apache2
    playbook: br-apache-playbook-ubuntu3
    playbook.url: http://localhost:8080/br-apache-playbook-ubuntu3.yaml
    ansible.vars:
      http_port: 8080
      some_other_test:
       - this
       - that
       - 'the other'
```
